### PR TITLE
fix: postCss searches folders recursively #68

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aurodesignsystem/auro-library",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aurodesignsystem/auro-library",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "handlebars": "^4.7.8",

--- a/scripts/build/postCss.mjs
+++ b/scripts/build/postCss.mjs
@@ -12,8 +12,7 @@ const __dirname = path.dirname(__filename);
 // Define possible directory paths
 const possiblePaths = [
   path.join(__dirname, '../src'),
-  path.join(__dirname, '../components'),
-  '/components'
+  path.join(__dirname, '../components')
 ];
 
 // Find the first existing directory

--- a/scripts/build/postCss.mjs
+++ b/scripts/build/postCss.mjs
@@ -1,63 +1,88 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
 import autoprefixer from 'autoprefixer';
 import postcss from 'postcss';
 import comments from 'postcss-discard-comments';
-import path from 'path';
-import fs from 'fs';
 
-const __dirname = new URL('.', import.meta.url).pathname;
-const directoryPath = path.join(__dirname, '../src');
+// Get the directory path
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
-/**
- * Default postCSS run
- * Locates all CSS files within the directory and loop
- * through the standardProcessor() function.
- */
-fs.readdir(directoryPath, function (err, files) {
-  //handling error
-  if (err) {
-    return console.log('Unable to scan directory: ' + err);
-  }
-  //listing all files using forEach
-  files.forEach(function (file) {
-    if (file.includes(".css")) {
-      standardProcessor(file);
+// Define possible directory paths
+const possiblePaths = [
+  path.join(__dirname, '../src'),
+  path.join(__dirname, '../components'),
+  '/components'
+];
+
+// Find the first existing directory
+export async function findExistingDirectory(paths) {
+  for (const dir of paths) {
+    try {
+      await fs.access(dir);
+      return dir;
+    } catch (error) {
+      console.log(error);
     }
-  });
-});
-
-/**
- * The standardProcessor function applies tokens for fallback selectors
- * and completes a post cleanup.
- * @param {string} file
- */
-function standardProcessor(file) {
- fs.readFile(`src/${file}`, (err, css) => {
-   postcss([autoprefixer, comments])
-   .use(comments({
-     remove: function(comment) { return comment[0] == "@"; }
-   }))
-   .process(css, { from: `src/${file}`, to: `src/${file}` })
-   .then(result => {
-     fs.writeFile(`src/${file}`, result.css, () => true)
-   })
- });
+  }
+  throw new Error('No valid directory found');
 }
 
 /**
- * ALTERNATE script:
- * The following is a static builder for rendering one
- * CSS file at a time if that is required.
+ * Recursively process CSS files in a directory and its subdirectories
+ * @param {string} dir - Directory to process
  */
-// fs.readFile('src/style.css', (err, css) => {
-//   postcss([autoprefixer, comments])
-//     .use(comments({
-//       remove: function(comment) { return comment[0] == "@"; }
-//     }))
-//     .process(css, { from: 'src/style.css', to: 'src/style.css' })
-//     .then(result => {
-//       fs.writeFile('src/style.css', result.css, () => true)
-//       if ( result.map ) {
-//         fs.writeFile('src/style.map', result.map, () => true)
-//       }
-//     })
-// });
+export async function processCssFiles(dir) {
+  try {
+    // Read contents of directory
+    const files = await fs.readdir(dir, { withFileTypes: true });
+    for (const file of files) {
+      const fullPath = path.join(dir, file.name);
+      // If it's a directory, recursively process it
+      if (file.isDirectory()) {
+        await processCssFiles(fullPath);
+      // If it's a CSS file, process it
+      } else if (path.extname(file.name).toLowerCase() === '.css') {
+        await processPostCss(fullPath);
+      }
+    }
+  } catch (err) {
+    console.error('Processing failed:', err);
+  }
+}
+
+/**
+ * Process CSS file(s) with PostCSS
+ * Applies autoprefixer and removes comments starting with '@'
+ * @param {string} filePath - Full path of CSS file to process
+ */
+export async function processPostCss(filePath) {
+  try {
+    // Read CSS file
+    const css = await fs.readFile(filePath, 'utf8');
+    // Process CSS with PostCSS plugins
+    const result = await postcss([
+      autoprefixer,
+      comments({
+        remove: comment => comment[0] === '@'
+      })
+    ]).process(css, { from: filePath, to: filePath });
+    // Write processed CSS back to the file
+    await fs.writeFile(filePath, result.css);
+    console.log(`Processed: ${filePath}`);
+  } catch (err) {
+    console.error(`Error processing ${filePath}:`, err);
+  }
+}
+
+// Init
+(async () => {
+  try {
+    const directoryPath = await findExistingDirectory(possiblePaths);
+    console.log(`Processing CSS files in: ${directoryPath}`);
+    await processCssFiles(directoryPath);
+  } catch (error) {
+    console.error('Error:', error.message);
+  }
+})();

--- a/scripts/build/postCss.mjs
+++ b/scripts/build/postCss.mjs
@@ -1,73 +1,49 @@
-import fs from 'fs/promises';
-import path from 'path';
-import { fileURLToPath } from 'url';
 import autoprefixer from 'autoprefixer';
 import postcss from 'postcss';
 import comments from 'postcss-discard-comments';
+import path from 'path';
+import fs from 'fs/promises';
 
-// Get the directory path
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-// Define possible directory paths
-const possiblePaths = [
+const __dirname = new URL('.', import.meta.url).pathname;
+const directories = [
   path.join(__dirname, '../src'),
   path.join(__dirname, '../components')
 ];
-
-// Find the first existing directory
-export async function findExistingDirectory(paths) {
-  for (const dir of paths) {
-    try {
-      await fs.access(dir);
-      return dir;
-    } catch (error) {
-      console.log(error);
-    }
-  }
-  throw new Error('No valid directory found');
-}
 
 /**
  * Recursively process CSS files in a directory and its subdirectories
  * @param {string} dir - Directory to process
  */
-export async function processCssFiles(dir) {
+async function processCssFiles(dir) {
   try {
-    // Read contents of directory
     const files = await fs.readdir(dir, { withFileTypes: true });
     for (const file of files) {
       const fullPath = path.join(dir, file.name);
-      // If it's a directory, recursively process it
       if (file.isDirectory()) {
         await processCssFiles(fullPath);
-      // If it's a CSS file, process it
       } else if (path.extname(file.name).toLowerCase() === '.css') {
         await processPostCss(fullPath);
       }
     }
   } catch (err) {
-    console.error('Processing failed:', err);
+    console.error(`Processing failed for directory ${dir}:`, err);
   }
 }
 
 /**
- * Process CSS file(s) with PostCSS
+ * Process CSS file with PostCSS
  * Applies autoprefixer and removes comments starting with '@'
  * @param {string} filePath - Full path of CSS file to process
  */
-export async function processPostCss(filePath) {
+async function processPostCss(filePath) {
   try {
-    // Read CSS file
     const css = await fs.readFile(filePath, 'utf8');
-    // Process CSS with PostCSS plugins
     const result = await postcss([
       autoprefixer,
       comments({
         remove: comment => comment[0] === '@'
       })
     ]).process(css, { from: filePath, to: filePath });
-    // Write processed CSS back to the file
     await fs.writeFile(filePath, result.css);
     console.log(`Processed: ${filePath}`);
   } catch (err) {
@@ -75,13 +51,15 @@ export async function processPostCss(filePath) {
   }
 }
 
-// Init
+// Main execution
 (async () => {
-  try {
-    const directoryPath = await findExistingDirectory(possiblePaths);
-    console.log(`Processing CSS files in: ${directoryPath}`);
-    await processCssFiles(directoryPath);
-  } catch (error) {
-    console.error('Error:', error.message);
+  for (const dir of directories) {
+    try {
+      await fs.access(dir);
+      console.log(`Processing CSS files in: ${dir}`);
+      await processCssFiles(dir);
+    } catch (error) {
+      console.log(`Directory not found or not accessible: ${dir}`);
+    }
   }
 })();


### PR DESCRIPTION
# Alaska Airlines Pull Request

Updating `postCss` to recursively search folders.

## Testing

Tested in two repositories:

- `auro-input`
- `auro-radio`

### Process

- Copied the file locally into `/node_modules/@aurodesignsystem/auro-library/scripts/build` and renamed it to `testPostCss.mjs`
- Updated the path in `package.json` to temporarily reference the updated `testPostCss.mjs` file:

```
"postCss:component": "node ./node_modules/@aurodesignsystem/auro-library/scripts/build/testPostCss.mjs",
```

- Ran `npm run build` which ran the `build:sass` task:

```
"build:sass": "npm-run-all build:sass:component postCss:component sass:render"
```

### Changes to `package.json`

#### `build:sass:component`

Based on the example present in the `auro-radio`'s `package.json`:

- Changed the `build:sass:component` command  in `auro-input` from:

```
"build:sass:component": "for file in src/*.scss; do npx sass --no-source-map \"$file:${file%.scss}.css\"; done",
```

to:

```
"build:sass:component": "sass --no-source-map src:src",
```

### `sass:render`

Updated `sass:render` to check recursively, and added the `/components/` folder:

```
"sass:render": "sass-render 'src/**/*.css' 'components/**/*.css' -t ./node_modules/@aurodesignsystem/auro-library/scripts/build/staticStyles-template.js"
```

### `sweep`

- Updated the `run sweep` command to check recursively
- Added the `./components` folder

```
"sweep": "find ./demo ./dist ./src ./components -type f \\( -name \"*.css\" -o -name \"*-css.js\" \\) -delete"
  },
```

### Confirming changes

- Using `npm run sweep`, any previous `.css` & `.js` files are cleaned from the repo
- Ran `npm run build` and observed the expected files being built:

#### `auro-input`

![Screenshot 2024-10-15 at 11 27 09 AM](https://github.com/user-attachments/assets/fac64769-463a-4627-9ced-c6509decd2ab)

- Created test subdirectories in `/src/` to further check recursive functionality:

![Screenshot 2024-10-15 at 11 22 46 AM](https://github.com/user-attachments/assets/0b2223bc-3f05-4950-911f-57ef606bc226)

## Before Submitting this pull request:
- Link all tickets in this repository related to this PR in the `Development` section
_note: all pull requests require at least one linked ticket_
- If this PR is `Ready For Review`, all ticket's linked under `Development` must have their status changed to `Ready For Review` as well

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I have performed a self-review of my own update.**