### PR TITLE
feat(api): `writeDepVersionFile` method will write the version of root

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aurodesignsystem/auro-library",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aurodesignsystem/auro-library",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "handlebars": "^4.7.8",

--- a/scripts/build/versionWriter.js
+++ b/scripts/build/versionWriter.js
@@ -13,10 +13,10 @@ const auroSubNameIndex = 5;
  */
 function writeDepVersionFile(pkg) {
   const fs = require('fs');
-  const path = `${pkg}/package.json`;
+  const path = pkg === 'root' ? require('path').relative(__dirname, './package.json') : `${pkg}/package.json`;
   const json = require(path);
   const {version} = json;
-  const elemSubName = pkg.substring(pkg.indexOf('auro-') + auroSubNameIndex);
+  const elemSubName = pkg === 'root' ? pkg : pkg.substring(pkg.indexOf('auro-') + auroSubNameIndex);
   const versionFilePath = `./src/${elemSubName}Version.js`;
 
   fs.writeFileSync(versionFilePath, `export default '${version}'`);


### PR DESCRIPTION
# Alaska Airlines Pull Request
`writeDepVersionFile('root')` will read the version from `./package.json` and write `rootVersion.js` file

This PR should be merged before https://github.com/AlaskaAirlines/auro-datepicker/issues/265


## Before Submitting this pull request:
- Link all tickets in this repository related to this PR in the `Development` section
_note: all pull requests require at least one linked ticket_
- If this PR is `Ready For Review`, all ticket's linked under `Development` must have their status changed to `Ready For Review` as well

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I have performed a self-review of my own update.**

## Summary by Sourcery

New Features:
- Introduce `writeDepVersionFile` method to read the version from the root `package.json` and write it to a `rootVersion.js` file.