### PR TITLE
fix: reference consuming component's package.json, rather than relatively

### DIFF
--- a/scripts/build/postinstall.mjs
+++ b/scripts/build/postinstall.mjs
@@ -2,8 +2,11 @@
 
 import chalk from 'chalk';
 import { createRequire } from 'node:module';
+import { resolve } from 'path';
+
+
 const require = createRequire(import.meta.url);
-const pjson = require('../package.json');
+const pjson = require(resolve(process.cwd(), 'package.json'));
 
 console.log(chalk.hex('#f26135')(`
 


### PR DESCRIPTION
When using `postInstall.mjs` as part of `auro-library`, the script attempts to reference a relative `package.json`:

```
const pjson = require('../package.json');
```

If a component such as `auro-input` is referencing `postInatll.mjs` from `auro-library`, the install fails since it cannot find a relative `package.json` inside `auro-library` `node_modules`:

```
Error: Cannot find module '../package.json'
```

The `postInstall` script should run from `node_modules` and reference the consuming component's `package.json`

# Alaska Airlines Pull Request

## Before Submitting this pull request:
- Link all tickets in this repository related to this PR in the `Development` section
_note: all pull requests require at least one linked ticket_
- If this PR is `Ready For Review`, all ticket's linked under `Development` must have their status changed to `Ready For Review` as well

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I have performed a self-review of my own update.**

## Summary by Sourcery

Bug Fixes:
- Fix the postInstall script to correctly reference the consuming component's package.json instead of a relative path.