### PR TITLE
Update markdown-magic

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   },
   "dependencies": {
     "handlebars": "^4.7.8",
-    "markdown-magic": "^2.6.1",
+    "markdown-magic": "^3.3.0",
     "npm-run-all": "^4.1.5"
   }
 }


### PR DESCRIPTION
# Alaska Airlines Pull Request

Auro-Library, which is used by every component has a dependency on `markdown-magic` version `2.6.1` 

This dependency then has dependencies on globby -> `glob@7.2.3` -> `inflight@1.0.6`. Both Glob and Inflight are marked as no longer supported as they cause memory leaks.

Upgrading to `markdown-magic@3.3.0` should remove these dependencies.

#80 