### PR TITLE
feat: adds .editoconfig file for IDE formatting

### DIFF
--- a/componentTemplates/formatting/.editorconfig
+++ b/componentTemplates/formatting/.editorconfig
@@ -1,0 +1,21 @@
+# Auro IDE config: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+# Matches markdown files
+[*.md]
+trim_trailing_whitespace = false
+
+# Windows files
+[*.bat]
+end_of_line = crlf

--- a/componentTemplates/formatting/.editorconfig
+++ b/componentTemplates/formatting/.editorconfig
@@ -15,7 +15,3 @@ indent_size = 2
 # Matches markdown files
 [*.md]
 trim_trailing_whitespace = false
-
-# Windows files
-[*.bat]
-end_of_line = crlf


### PR DESCRIPTION
# Alaska Airlines Pull Request

When sharing code across developers and their respective IDEs, we want to maintain consistency in the way Auro code is committed to the repository.

By creating an `.editorconfig`  file, we can inform IDEs how to format and save code, ensuring uniform styles and minimizing formatting-related issues.

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I have performed a self-review of my own update.**