### PR TITLE
build(docs): simplify wca component's description #87

### DIFF
--- a/scripts/build/prepWcaCompatibleCode.mjs
+++ b/scripts/build/prepWcaCompatibleCode.mjs
@@ -1,7 +1,7 @@
 export default (code, sourcePath) => {
   const defaultTag = (code.match(/static register\(name \= (.+)\)/) || code.match(/customElements.get\((.+?)\)/))[1];
   const className = code.match(/export class (.+) extends/)?.[1];
-  const classDesc = code.match(/\/\*\*((.|\n)*?)\*\//)?.[1] || '';
+  const classDesc = code.match(/\/\*\*((.|\n)*?)(\*\n|\*\/)/)?.[1] || '';
 
   if (!defaultTag || !className) {
     return code;


### PR DESCRIPTION
# Alaska Airlines Pull Request

#87 

This change is to simplify the description comment in the generated wca component (by `generateWcaComponent.mjs`)
The new description won't have the comment about any attribute, slot, etc (`@(.*)`)


**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I have performed a self-review of my own update.**

## Summary by Sourcery

Build:
- Simplify the description comment in the generated WCA component by modifying the script to exclude comments about attributes, slots, etc.