### PR TITLE
fix: automatically create `docTemplate` when generating docs #94

### DIFF
--- a/scripts/utils/auroFileHandler.mjs
+++ b/scripts/utils/auroFileHandler.mjs
@@ -1,4 +1,5 @@
 import fs from 'node:fs/promises';
+import path from 'node:path';
 
 import {Logger} from "../utils/logger.mjs";
 
@@ -40,7 +41,12 @@ export class AuroFileHandler {
    * @returns {Promise<boolean>}
    */
   static async tryWriteFile(filePath, fileContents) {
-    try {
+    try { 
+      const dirname = path.dirname(filePath);
+      const dirExists = await this.exists(dirname);
+      if (!dirExists) {
+        await fs.mkdir(dirname, {recursive: true});
+      }
       await fs.writeFile(filePath, fileContents, {encoding: 'utf-8'});
       return true;
     } catch (err) {

--- a/scripts/utils/auroFileHandler.mjs
+++ b/scripts/utils/auroFileHandler.mjs
@@ -43,10 +43,7 @@ export class AuroFileHandler {
   static async tryWriteFile(filePath, fileContents) {
     try { 
       const dirname = path.dirname(filePath);
-      const dirExists = await this.exists(dirname);
-      if (!dirExists) {
-        await fs.mkdir(dirname, {recursive: true});
-      }
+      await fs.mkdir(dirname, {recursive: true});
       await fs.writeFile(filePath, fileContents, {encoding: 'utf-8'});
       return true;
     } catch (err) {


### PR DESCRIPTION
# Alaska Airlines Pull Request


Automatically create `docTemplate` when downloading README.md

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I have performed a self-review of my own update.**

## Summary by Sourcery

Bug Fixes:
- Ensure the `docTemplate` directory is automatically created if it does not exist when generating documentation.