### PR TITLE
fix: force focus state to dropdown.trigger as `document.activeElement` stays in body even with clicking #99

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "@aurodesignsystem/auro-library",
-  "version": "3.0.2",
+  "version": "3.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aurodesignsystem/auro-library",
-      "version": "3.0.2",
+      "version": "3.0.4",
       "license": "Apache-2.0",
       "dependencies": {
+        "@floating-ui/dom": "^1.6.11",
         "handlebars": "^4.7.8",
         "markdown-magic": "^2.6.1",
         "npm-run-all": "^4.1.5"
@@ -967,6 +968,31 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.8.tgz",
+      "integrity": "sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.8"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.6.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.12.tgz",
+      "integrity": "sha512-NP83c0HjokcGVEMeoStg317VD9W7eDlGK7457dMBANbKA6GJZdc7rjujdgqzTaz93jkGgc5P/jeWbaCHnMNc+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.6.0",
+        "@floating-ui/utils": "^0.2.8"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.8.tgz",
+      "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==",
+      "license": "MIT"
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
   "dependencies": {
     "handlebars": "^4.7.8",
     "markdown-magic": "^2.6.1",
+    "@floating-ui/dom": "^1.6.11",
     "npm-run-all": "^4.1.5"
   }
 }

--- a/scripts/runtime/floatingUI.mjs
+++ b/scripts/runtime/floatingUI.mjs
@@ -314,6 +314,9 @@ export default class AuroFloatingUI {
           this.handleFocusLoss();
           break;
         case 'click':
+          if (document.activeElement === document.body) {
+            event.currentTarget.focus();
+          }
           this.handleClick();
           break;
         default:


### PR DESCRIPTION
Related to: https://github.com/AlaskaAirlines/auro-formkit/issues/129

# Alaska Airlines Pull Request

## Before Submitting this pull request:
- Link all tickets in this repository related to this PR in the `Development` section
_note: all pull requests require at least one linked ticket_
- If this PR is `Ready For Review`, all ticket's linked under `Development` must have their status changed to `Ready For Review` as well

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I have performed a self-review of my own update.**

## Summary by Sourcery

Fix focus state management in dropdown component to ensure correct element receives focus on click.

Bug Fixes:
- Fix an issue where clicking the dropdown trigger would not correctly set the focus state, resulting in the document body retaining focus instead of the trigger element.

Enhancements:
- Update dropdown component to use `@floating-ui/dom` for improved focus management.