### PR TITLE
fix: fix runtime error on floatingui with no trigger slot

### DIFF
--- a/scripts/runtime/floatingUI.mjs
+++ b/scripts/runtime/floatingUI.mjs
@@ -238,6 +238,7 @@ export default class AuroFloatingUI {
       this.updateCurrentExpandedDropdown();
       this.element.isPopoverVisible = true;
       this.element.triggerChevron?.setAttribute('data-expanded', true);
+      document.body.style.overflow = 'hidden';
       this.dispatchEventDropdownToggle();
       this.position();
       
@@ -255,6 +256,7 @@ export default class AuroFloatingUI {
   hideBib() {
     if (this.element.isPopoverVisible && !this.element.disabled && !this.element.noToggle) {
       this.element.isPopoverVisible = false;
+      document.body.style.overflow = '';
       this.element.triggerChevron?.removeAttribute('data-expanded');
       this.dispatchEventDropdownToggle();
     }

--- a/scripts/runtime/floatingUI.mjs
+++ b/scripts/runtime/floatingUI.mjs
@@ -114,8 +114,14 @@ export default class AuroFloatingUI {
       bibContent.style.height = '';
       bibContent.style.maxWidth = '';
       bibContent.style.maxHeight = '';
+
+      if (this.element.isPopoverVisible) {
+        document.body.style.overflow = 'hidden';
+      }
     } else {
       this.element.isBibFullscreen = false;
+
+      document.body.style.overflow = '';
     }
 
     if (prevStrategy !== strategy) {
@@ -232,7 +238,7 @@ export default class AuroFloatingUI {
       this.updateCurrentExpandedDropdown();
       this.element.isPopoverVisible = true;
       this.element.triggerChevron?.setAttribute('data-expanded', true);
-      document.body.style.overflow = 'hidden';
+      
       this.dispatchEventDropdownToggle();
       this.position();
       


### PR DESCRIPTION
# Alaska Airlines Pull Request

This is to support combobox fullscreen where input moves between bib and trigger.
- fix runtime error when to open the bib without trigger slot
- lock the body scroll while bib is open
- dispatch `strategy-change` event when bib changes the mode between fullscreen and floating

related to https://github.com/AlaskaAirlines/auro-formkit/issues/322

## Before Submitting this pull request:
- Link all tickets in this repository related to this PR in the `Development` section
_note: all pull requests require at least one linked ticket_
- If this PR is `Ready For Review`, all ticket's linked under `Development` must have their status changed to `Ready For Review` as well

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I have performed a self-review of my own update.**

## Summary by Sourcery

Fix a runtime error in the floatingUI component when no trigger slot is present. Ensure correct state updates and event dispatching for fullscreen combobox transitions. Correct the `isPopoverVisible` property usage in custom events. Improve handling of fullscreen and mirror size states in combobox transitions.

Bug Fixes:
- Fix runtime error when there is no trigger slot in floatingUI component by adding a check for the existence of the trigger node before accessing it, preventing crashes in specific scenarios like combobox fullscreen mode where the input moves between bib and trigger.
- Fix an issue where the fullscreen combobox would not correctly update its state when transitioning between fullscreen and non-fullscreen modes by dispatching a `strategy-change` event when the positioning strategy changes.
- Fix an issue where the `isPopoverVisible` property was not correctly reflected in the `toggled` and `triggerClick` custom events by ensuring the events detail object uses the correct property from the element.
- Fix an issue where the combobox would not correctly transition between fullscreen and non-fullscreen modes by correctly setting the fullscreen and mirror size states only when the strategy changes, preventing unnecessary updates and ensuring proper rendering.