### PR TITLE
fix: make bib not to get pushed up by keyboard

### DIFF
--- a/scripts/runtime/floatingUI.mjs
+++ b/scripts/runtime/floatingUI.mjs
@@ -93,6 +93,20 @@ export default class AuroFloatingUI {
 
   /**
    * @private
+   * scroll body lock
+   * @param {Boolean} lock - unlock scroll when it's false
+   */
+  lockScroll(lock = true) {
+    if (lock) {
+      document.body.style.overflow = 'hidden'; // hide body's scrollbar
+      this.element.bib.style.transform = `translateY(${visualViewport.offsetTop}px)`;
+    } else {
+      document.body.style.overflow = '';
+    }
+  }
+
+  /**
+   * @private
    * Configures the bib element's display strategy.
    *
    * Sets the bib to fullscreen or floating mode based on the provided strategy.
@@ -113,15 +127,15 @@ export default class AuroFloatingUI {
       bibContent.style.width = '';
       bibContent.style.height = '';
       bibContent.style.maxWidth = '';
-      bibContent.style.maxHeight = '';
+      bibContent.style.maxHeight = `${window.visualViewport.height}px`;
 
       if (this.element.isPopoverVisible) {
-        document.body.style.overflow = 'hidden';
+        this.lockScroll(true);
       }
     } else {
       this.element.isBibFullscreen = false;
 
-      document.body.style.overflow = '';
+      this.lockScroll(false);
     }
 
     if (prevStrategy !== strategy) {
@@ -256,7 +270,7 @@ export default class AuroFloatingUI {
   hideBib() {
     if (this.element.isPopoverVisible && !this.element.disabled && !this.element.noToggle) {
       this.element.isPopoverVisible = false;
-      document.body.style.overflow = '';
+      this.lockScroll(false);
       this.element.triggerChevron?.removeAttribute('data-expanded');
       this.dispatchEventDropdownToggle();
     }

--- a/scripts/runtime/floatingUI.mjs
+++ b/scripts/runtime/floatingUI.mjs
@@ -93,12 +93,14 @@ export default class AuroFloatingUI {
 
   /**
    * @private
-   * scroll body lock
-   * @param {Boolean} lock - unlock scroll when it's false
+   * Controls whether to lock the scrolling for the document's body.
+   * @param {Boolean} lock - If true, locks the body's scrolling functionlity; otherwise, unlock.
    */
   lockScroll(lock = true) {
     if (lock) {
       document.body.style.overflow = 'hidden'; // hide body's scrollbar
+
+      // Move `bib` by the amount the viewport is shifted to stay aligned in fullscreen.
       this.element.bib.style.transform = `translateY(${visualViewport.offsetTop}px)`;
     } else {
       document.body.style.overflow = '';


### PR DESCRIPTION
# Alaska Airlines Pull Request

### Current Issue
mobile only, 
When bib is open in fullscreen with a focused input, vkb pushes off the entire viewport

### Solution
Transform bib to viewport offset. // currently there is no way to change viewport offset programmatically

## Before Submitting this pull request:
- Link all tickets in this repository related to this PR in the `Development` section
_note: all pull requests require at least one linked ticket_
- If this PR is `Ready For Review`, all ticket's linked under `Development` must have their status changed to `Ready For Review` as well

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I have performed a self-review of my own update.**

## Summary by Sourcery

Addresses a mobile-specific layout issue where the virtual keyboard interfered with the bib's display in fullscreen mode. The solution involves adjusting the bib's position using `translateY` and managing the body's overflow to prevent the viewport from being pushed off-screen.

Bug Fixes:
- Fixes an issue on mobile where the virtual keyboard would push the entire viewport off-screen when the bib (likely a bottom information bar) is open in fullscreen with a focused input.

Enhancements:
- Improves the management of the document body's overflow property when the bib is in fullscreen mode by introducing a `lockScroll` method.