### PR TITLE
fix: hide bib correctly when losing focus on trigger

### DIFF
--- a/scripts/runtime/floatingUI.mjs
+++ b/scripts/runtime/floatingUI.mjs
@@ -242,8 +242,7 @@ export default class AuroFloatingUI {
     }
 
     const { activeElement } = document;
-    if (activeElement === document.querySelector('body') ||
-      this.element.contains(activeElement) ||
+    if (this.element.contains(activeElement) ||
       this.element.bib?.contains(activeElement)) {
       return;
     }


### PR DESCRIPTION
# Alaska Airlines Pull Request

This is
- To hide floatingUI bib when trigger losing focus
- Not to reset `document.activeElement` on clicking bib's background

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Improve focus handling for floating UI bib to prevent unintended hiding and maintain better focus management

Bug Fixes:
- Fix issue with floating UI bib hiding incorrectly when losing focus
- Prevent unintended document.activeElement reset when interacting with bib

Enhancements:
- Refine focus loss detection logic
- Add preventive measures to maintain UI state during user interactions