### PR TITLE
feat: add an advanced `iterate()` to test the given action AND a11y

### DIFF
--- a/scripts/test-plugin/iterateWithA11Check.mjs
+++ b/scripts/test-plugin/iterateWithA11Check.mjs
@@ -1,0 +1,82 @@
+import { expect } from '@open-wc/testing';
+
+let originalIt;
+async function checkElementAccessibility(element) {
+  // test only when this element is meaningful.
+  if (element.children.length || element.attributes.length) {
+    await expect(element).to.be.accessible();
+  }
+}
+
+function aIt(desc, action) {
+  const actionWithA11y = async () => {
+    const result = await action();
+
+    let rootElement;
+    if (typeof result === 'string') {
+      rootElement = document.querySelector(result);
+    } else if (result instanceof Element) {
+      rootElement = result;
+    } else {
+      // fallback incase `action()` didnt return the created node.
+      // The framework injdect any elements that are created during `action()` to first `div` layer under `body`.
+      // this `div` will get cleared after the iteration.
+      rootElement = document.body.querySelector('div');
+    }
+
+    if (rootElement) {
+      await checkElementAccessibility(rootElement);
+    }
+
+    const children = [...document.body.children];
+    for (let child of children) {
+      if (child !== rootElement) {
+        // when the iteration's element uses `floatingUI`, there will be an extra child under `body`.
+        if (
+          child.hasAttribute("auro-dropdownbib") ||
+          child.hasAttribute("auro-floater-bib")
+        ) {
+          // test `floatingUI.bib`
+          await checkElementAccessibility(child);
+        }
+      }
+    }
+  };
+
+  originalIt(desc, actionWithA11y);
+}
+
+/**
+ * Usage Example
+ * 
+ * import { getAccessibleIt } from "@aurodesignsystem/auro-library/scripts/test-plugin/iterateWithA11Check.mjs";
+ * 
+ * it = getAccessibleIt();
+ * 
+ * OR
+ * 
+ * import { getAccessibleIt } from "@aurodesignsystem/auro-library/scripts/test-plugin/iterateWithA11Check.mjs";
+ * 
+ * aIt = getAccessibleIt();
+ * 
+ * describe('test', () => {
+ *   aIt('description', () => {
+ *     ...
+ *   }
+ * });
+ */
+export function getAccessibleIt() {
+  originalIt ??= it;
+  return aIt;
+}
+
+/**
+ * Usage Example
+ * 
+ * import { useAccessibleIt } from "@aurodesignsystem/auro-library/scripts/test-plugin/iterateWithA11Check.mjs";
+ * useAccessibleIt();
+ */
+export function useAccessibleIt() {
+  originalIt ??= it;
+  it = aIt;
+}


### PR DESCRIPTION
# Alaska Airlines Pull Request

This script will run test with extra a11y test after every iteration.

To use this script, 
Just add these 2 line on top of `*.test.js` and that'll be it.
```
import { useAccessibleIt } from "@aurodesignsystem/auro-library/scripts/test-plugin/iterateWithA11Check.mjs";
useAccessibleIt();

// write your test as usual
```

or 

```
import { getAccessibleIt } from "@aurodesignsystem/auro-library/scripts/test-plugin/iterateWithA11Check.mjs";
aIt = getAccessibleIt();
 
// write your test using `aIt()` instead of `it()`
```

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Add a new testing utility function `aIt()` that combines action testing with accessibility checking

New Features:
- Create an advanced testing utility that runs an action and automatically checks document accessibility

Tests:
- Implement a wrapper function that integrates action testing with accessibility verification