### PR TITLE
perf: add deep nested focusable elements support in focustrap

### DIFF
--- a/scripts/runtime/FocusTrap/FocusTrap.mjs
+++ b/scripts/runtime/FocusTrap/FocusTrap.mjs
@@ -58,10 +58,12 @@ export class FocusTrap {
       // Get the active element(s) in the document and shadow root
       // This will include the active element in the shadow DOM if it exists
       // Active element may be inside the shadow DOM depending on delegatesFocus, so we need to check both
-      const actives =  [
-        document.activeElement,
-        ...document.activeElement.shadowRoot && [document.activeElement.shadowRoot.activeElement] || []
-      ]
+      let activeElement = document.activeElement;
+      const actives =  [activeElement];
+      while (activeElement?.shadowRoot?.activeElement) {
+        actives.push(activeElement.shadowRoot.activeElement);
+        activeElement = activeElement.shadowRoot.activeElement;
+      }
 
       // Update the focusable elements
       const focusables = this._getFocusableElements();


### PR DESCRIPTION
# Alaska Airlines Pull Request

This is to support the case when actual focused element is in 2+ deeper shadowDom level.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Enhancements:
- Support deep nested focusable elements in FocusTrap by iteratively traversing each shadowRoot’s activeElement