### PR TITLE
fix: remove mousedown `preventDefault` on bib

### DIFF
--- a/scripts/runtime/floatingUI.mjs
+++ b/scripts/runtime/floatingUI.mjs
@@ -319,12 +319,6 @@ export default class AuroFloatingUI {
   }
 
   setupHideHandlers() {
-    this.preventFocusLoseOnBibClick = (event) => {
-      event.preventDefault();
-      event.stopPropagation();
-    };
-    this.element.bib.addEventListener('mousedown', this.preventFocusLoseOnBibClick);
-
     // Define handlers & store references
     this.focusHandler = () => this.handleFocusLoss();
 
@@ -373,11 +367,6 @@ export default class AuroFloatingUI {
 
   cleanupHideHandlers() {
     // Remove event listeners if they exist
-
-    if (this.preventFocusLoseOnBibClick) {
-      this.element.bib.removeEventListener('mousedown', this.preventFocusLoseOnBibClick);
-      delete this.preventFocusLoseOnBibClick;
-    }
 
     if (this.focusHandler) {
       document.removeEventListener('focusin', this.focusHandler);


### PR DESCRIPTION
# Alaska Airlines Pull Request

closes https://github.com/AlaskaAirlines/auro-library/issues/184

removing `preventDefault` on mousedown on bib which was blocking selecting/highlighting texts inside of bib.
>  mousedown inside bib does not change `document.activeElement` so bib won't get closed even without `preventDefault`

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Bug Fixes:
- Drop the mousedown preventDefault and stopPropagation handlers on the bib element to ensure document.activeElement updates and the bib can close.