### PR TITLE
feat: add support for controlling tab order to FocusTrap

### DIFF
--- a/scripts/runtime/Focusables/Focusables.mjs
+++ b/scripts/runtime/Focusables/Focusables.mjs
@@ -21,7 +21,7 @@ export const FOCUSABLE_COMPONENTS = [
   'auro-combobox',
   'auro-input',
   'auro-counter',
-  'auro-menu',
+  // 'auro-menu', // Auro menu is not focusable by default, it uses a different interaction model
   'auro-select',
   'auro-datepicker',
   'auro-hyperlink',
@@ -54,6 +54,7 @@ export function isFocusableComponent(element) {
 /**
  * Retrieves all focusable elements within the container in DOM order, including those in shadow DOM and slots.
  * Returns a unique, ordered array of elements that can receive focus.
+ * Also sorts elements with tabindex first, preserving their order.
  *
  * @param {HTMLElement} container The container to search within
  * @returns {Array<HTMLElement>} An array of focusable elements within the container.
@@ -125,5 +126,25 @@ export function getFocusableElements(container) {
     }
   }
 
-  return uniqueElements;
+  // Move tab-indexed elements to the front while preserving their order
+  // This ensures that elements with tabindex are prioritized in the focus order
+
+  // First extract elements with tabindex
+  const elementsWithTabindex = uniqueElements.filter(el => el.hasAttribute('tabindex'));
+
+  // Sort these elements by their tabindex value
+  elementsWithTabindex.sort((a, b) => {
+    return parseInt(a.getAttribute('tabindex'), 10) - parseInt(b.getAttribute('tabindex'), 10);
+  });
+
+  // Elements without tabindex (preserving their original order)
+  const elementsWithoutTabindex = uniqueElements.filter(el => !el.hasAttribute('tabindex'));
+
+  // Combine both arrays with tabindex elements first
+  const tabIndexedUniqueElements = [
+    ...elementsWithTabindex,
+    ...elementsWithoutTabindex
+  ];
+
+  return tabIndexedUniqueElements;
 }


### PR DESCRIPTION
# Alaska Airlines Pull Request

- Update focus trap with `controlTabOrder` argument in constructor
- `controlTabOrder` argument is `false` by default
- Update tab listener function to manually control next tab element when `controlTabOrder` is true
- Update `_getFocusabledElements` to account for `tabindex` property and move elements with `tabindex` in order to the beginning of the tab flow

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
