### PR TITLE
Feature: add support for controlling tab order to FocusTrap

### DIFF
--- a/scripts/runtime/FocusTrap/FocusTrap.mjs
+++ b/scripts/runtime/FocusTrap/FocusTrap.mjs
@@ -42,11 +42,16 @@ export class FocusTrap {
     this.container.addEventListener('keydown', this._onKeydown);
   }
 
+  /**
+   * Gets an array of currently active (focused) elements in the document and shadow DOM.
+   * @returns {Array<HTMLElement>} An array of focusable elements within the container.
+   * @private
+   */
   _getActiveElements() {
     // Get the active element(s) in the document and shadow root
     // This will include the active element in the shadow DOM if it exists
     // Active element may be inside the shadow DOM depending on delegatesFocus, so we need to check both
-    let activeElement = document.activeElement;
+    let {activeElement} = document;
     const actives =  [activeElement];
     while (activeElement?.shadowRoot?.activeElement) {
       actives.push(activeElement.shadowRoot.activeElement);
@@ -55,6 +60,12 @@ export class FocusTrap {
     return actives;
   }
 
+  /**
+   * Gets the next focus index based on the current index and focusable elements.
+   * @param {number} currentIndex The current index of the focused element.
+   * @param {Array<HTMLElement>} focusables The array of focusable elements.
+   * @returns {number|null} The next focus index or null if not determined.
+   */
   _getNextFocusIndex(currentIndex, focusables) {
 
     let newFocusIndex = null;
@@ -109,6 +120,7 @@ export class FocusTrap {
     if (focusIndex === -1) focusIndex = 0;
 
     // Get the next focus index based on the current focus index, tab direction, and controlTabOrder setting
+    // Is null if no new focus index is determined
     let newFocusIndex = this._getNextFocusIndex(focusIndex, focusables);
 
     // If we have a new focus index, set focus to that element
@@ -140,7 +152,7 @@ export class FocusTrap {
     // Use the imported utility function to get focusable elements
     const elements = getFocusableElements(this.container);
     
-    // Filter out any elements with the 'focus-bookend' class
+    // Return the elements found
     return elements;
   }
 

--- a/scripts/runtime/FocusTrap/FocusTrap.mjs
+++ b/scripts/runtime/FocusTrap/FocusTrap.mjs
@@ -10,6 +10,7 @@ export class FocusTrap {
    * Initializes event listeners and prepares the container for focus management.
    *
    * @param {HTMLElement} container The DOM element to trap focus within.
+   * @param {boolean} [controlTabOrder=false] If true enables manual control of the tab order by the FocusTrap.
    * @throws {Error} If the provided container is not a valid HTMLElement.
    */
   constructor(container, controlTabOrder = false) {

--- a/scripts/runtime/FocusTrap/FocusTrap.mjs
+++ b/scripts/runtime/FocusTrap/FocusTrap.mjs
@@ -55,6 +55,35 @@ export class FocusTrap {
     return actives;
   }
 
+  _getNextFocusIndex(currentIndex, focusables) {
+
+    let newFocusIndex = null;
+
+    // If controlTabOrder is true, we will manually control the tab order
+    if (this.controlTabOrder) {
+
+      // Adjust to new index
+      newFocusIndex = currentIndex + (this.tabDirection === 'forward' ? 1 : -1);
+
+      // Wrap if necessary
+      if (newFocusIndex < 0 && this.tabDirection === 'backward') newFocusIndex = focusables.length - 1;
+      if (newFocusIndex >= focusables.length && this.tabDirection === 'forward') newFocusIndex = 0;
+    } else {
+
+      // Wrap backwards
+      if ((actives.includes(focusables[0]) || actives.includes(this.container)) && this.tabDirection === 'backward') {
+        newFocusIndex = focusables.length - 1;
+      }
+
+      // Wrap forwards
+      if (actives.includes(focusables[focusables.length - 1]) && this.tabDirection === 'forward') {
+        newFocusIndex = 0;
+      }
+    }
+
+    return newFocusIndex;
+  }
+
   /**
    * Handles keydown events to manage tab navigation within the container.
    * Ensures that focus wraps around when reaching the first or last focusable element.
@@ -83,36 +112,12 @@ export class FocusTrap {
       // Fallback if we have no focused element
       if (focusIndex === -1) focusIndex = 0;
 
-      let newFocusIndex;
+      // Get the next focus index based on the current focus index, tab direction, and controlTabOrder setting
+      let newFocusIndex = this._getNextFocusIndex(focusIndex, focusables);
 
-      // If controlTabOrder is true, we will manually control the tab order
-      if (this.controlTabOrder) {
-
-        // Don't let the browser handle the tabbing
-        e.preventDefault();
-
-        // Adjust to new index
-        newFocusIndex = focusIndex + (this.tabDirection === 'forward' ? 1 : -1);
-
-        // Wrap if necessary
-        if (newFocusIndex < 0 && this.tabDirection === 'backward') newFocusIndex = focusables.length - 1;
-        if (newFocusIndex >= focusables.length && this.tabDirection === 'forward') newFocusIndex = 0;
-      } else {
-
-        // Wrap backwards
-        if ((actives.includes(focusables[0]) || actives.includes(this.container)) && this.tabDirection === 'backward') {
-          e.preventDefault();
-          newFocusIndex = focusables.length - 1;
-        }
-
-        // Wrap forwards
-        if (actives.includes(focusables[focusables.length - 1]) && this.tabDirection === 'forward') {
-          e.preventDefault();
-          newFocusIndex = 0;
-        }
-      }
-
+      // If we have a new focus index, set focus to that element
       if (newFocusIndex !== null) {
+        e.preventDefault();
         focusables[newFocusIndex].focus();
       }
     }

--- a/scripts/runtime/FocusTrap/FocusTrap.mjs
+++ b/scripts/runtime/FocusTrap/FocusTrap.mjs
@@ -85,42 +85,48 @@ export class FocusTrap {
   }
 
   /**
-   * Handles keydown events to manage tab navigation within the container.
-   * Ensures that focus wraps around when reaching the first or last focusable element.
-   *
+   * Handles the Tab key press event to manage focus within the container.
+   * @param {KeyboardEvent} e The keyboard event triggered by the user.
+   * @returns {void}
+   */
+  _handleTabKey(e) {
+
+    // Update the focusable elements
+    const focusables = this._getFocusableElements();
+
+    if (!focusables.length) return;
+
+    // Set the tab direction based on the key pressed
+    this.tabDirection = e.shiftKey ? 'backward' : 'forward';
+
+    // Get the active elements that are currently focused
+    const actives = this._getActiveElements();
+
+    // If we're at either end of the focusable elements, wrap around to the other end
+    let focusIndex = focusables.findIndex((el) => actives.includes(el));
+
+    // Fallback if we have no focused element
+    if (focusIndex === -1) focusIndex = 0;
+
+    // Get the next focus index based on the current focus index, tab direction, and controlTabOrder setting
+    let newFocusIndex = this._getNextFocusIndex(focusIndex, focusables);
+
+    // If we have a new focus index, set focus to that element
+    if (newFocusIndex !== null) {
+      e.preventDefault();
+      focusables[newFocusIndex].focus();
+    }
+  }
+
+  /**
+   * Catches the keydown event
    * @param {KeyboardEvent} e The keyboard event triggered by user interaction.
    * @private
    */
   _onKeydown = (e) => {
-    
-    if (e.key === 'Tab') {
 
-      // Update the focusable elements
-      const focusables = this._getFocusableElements();
-
-      if (!focusables.length) return;
-
-      // Set the tab direction based on the key pressed
-      this.tabDirection = e.shiftKey ? 'backward' : 'forward';
-
-      // Get the active elements that are currently focused
-      const actives = this._getActiveElements();
-
-      // If we're at either end of the focusable elements, wrap around to the other end
-      let focusIndex = focusables.findIndex((el) => actives.includes(el));
-
-      // Fallback if we have no focused element
-      if (focusIndex === -1) focusIndex = 0;
-
-      // Get the next focus index based on the current focus index, tab direction, and controlTabOrder setting
-      let newFocusIndex = this._getNextFocusIndex(focusIndex, focusables);
-
-      // If we have a new focus index, set focus to that element
-      if (newFocusIndex !== null) {
-        e.preventDefault();
-        focusables[newFocusIndex].focus();
-      }
-    }
+    // Handle tab
+    if (e.key === 'Tab') this._handleTabKey(e);
   };
 
   /**

--- a/scripts/runtime/FocusTrap/FocusTrap.mjs
+++ b/scripts/runtime/FocusTrap/FocusTrap.mjs
@@ -66,7 +66,7 @@ export class FocusTrap {
    * @param {Array<HTMLElement>} focusables The array of focusable elements.
    * @returns {number|null} The next focus index or null if not determined.
    */
-  _getNextFocusIndex(currentIndex, focusables) {
+  _getNextFocusIndex(currentIndex, focusables, actives) {
 
     let newFocusIndex = null;
 
@@ -121,7 +121,7 @@ export class FocusTrap {
 
     // Get the next focus index based on the current focus index, tab direction, and controlTabOrder setting
     // Is null if no new focus index is determined
-    let newFocusIndex = this._getNextFocusIndex(focusIndex, focusables);
+    let newFocusIndex = this._getNextFocusIndex(focusIndex, focusables, actives);
 
     // If we have a new focus index, set focus to that element
     if (newFocusIndex !== null) {

--- a/scripts/runtime/Focusables/Focusables.mjs
+++ b/scripts/runtime/Focusables/Focusables.mjs
@@ -21,7 +21,7 @@ export const FOCUSABLE_COMPONENTS = [
   'auro-combobox',
   'auro-input',
   'auro-counter',
-  'auro-menu',
+  // 'auro-menu', // Auro menu is not focusable by default, it uses a different interaction model
   'auro-select',
   'auro-datepicker',
   'auro-hyperlink',
@@ -54,6 +54,7 @@ export function isFocusableComponent(element) {
 /**
  * Retrieves all focusable elements within the container in DOM order, including those in shadow DOM and slots.
  * Returns a unique, ordered array of elements that can receive focus.
+ * Also sorts elements with tabindex first, preserving their order.
  *
  * @param {HTMLElement} container The container to search within
  * @returns {Array<HTMLElement>} An array of focusable elements within the container.
@@ -125,5 +126,25 @@ export function getFocusableElements(container) {
     }
   }
 
-  return uniqueElements;
+  // Move tab-indexed elements to the front while preserving their order
+  // This ensures that elements with tabindex are prioritized in the focus order
+
+  // First extract elements with tabindex
+  const elementsWithTabindex = uniqueElements.filter(el => el.hasAttribute('tabindex'));
+
+  // Sort these elements by their tabindex value
+  elementsWithTabindex.sort((a, b) => {
+    return parseInt(a.getAttribute('tabindex'), 10) - parseInt(b.getAttribute('tabindex'), 10);
+  });
+
+  // Elements without tabindex (preserving their original order)
+  const elementsWithoutTabindex = uniqueElements.filter(el => !el.hasAttribute('tabindex'));
+
+  // Combine both arrays with tabindex elements first
+  const tabIndexedUniqueElements = [
+    ...elementsWithTabindex,
+    ...elementsWithoutTabindex
+  ];
+
+  return tabIndexedUniqueElements;
 }

--- a/scripts/runtime/Focusables/Focusables.mjs
+++ b/scripts/runtime/Focusables/Focusables.mjs
@@ -130,7 +130,7 @@ export function getFocusableElements(container) {
   // This ensures that elements with tabindex are prioritized in the focus order
 
   // First extract elements with tabindex
-  const elementsWithTabindex = uniqueElements.filter(el => el.hasAttribute('tabindex'));
+  const elementsWithTabindex = uniqueElements.filter(el => el.hasAttribute('tabindex') && (parseInt(el.getAttribute('tabindex')) ?? -1) > 0);
 
   // Sort these elements by their tabindex value
   elementsWithTabindex.sort((a, b) => {

--- a/scripts/runtime/Focusables/test/Focusables.test.js
+++ b/scripts/runtime/Focusables/test/Focusables.test.js
@@ -10,7 +10,7 @@ describe('isFocusableComponent', () => {
   it('returns true for enabled custom focusable components', async () => {
     for (const tag of [
       'auro-checkbox', 'auro-radio', 'auro-dropdown', 'auro-button', 'auro-combobox',
-      'auro-input', 'auro-counter', 'auro-menu', 'auro-select', 'auro-datepicker',
+      'auro-input', 'auro-counter', 'auro-select', 'auro-datepicker',
       'auro-hyperlink', 'auro-accordion'
     ]) {
       const el = document.createElement(tag);
@@ -26,7 +26,7 @@ describe('isFocusableComponent', () => {
   it('returns false for custom components with disabled attribute', async () => {
     for (const tag of [
       'auro-checkbox', 'auro-radio', 'auro-dropdown', 'auro-button', 'auro-combobox',
-      'auro-input', 'auro-counter', 'auro-menu', 'auro-select', 'auro-datepicker',
+      'auro-input', 'auro-counter', 'auro-select', 'auro-datepicker',
       'auro-hyperlink', 'auro-accordion'
     ]) {
       const el = document.createElement(tag);


### PR DESCRIPTION
# Alaska Airlines Pull Request

- Update focus trap with `controlTabOrder` argument in constructor
- `controlTabOrder` argument is `false` by default
- Update tab listener function to manually control next tab element when `controlTabOrder` is true
- Update `_getFocusabledElements` to account for `tabindex` property and move elements with `tabindex` in order to the beginning of the tab flow

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
