### PR TITLE
fix: null check on `window.visualViewport` in floatingUI

### DIFF
--- a/scripts/runtime/floatingUI.mjs
+++ b/scripts/runtime/floatingUI.mjs
@@ -207,7 +207,7 @@ export default class AuroFloatingUI {
       document.body.style.overflow = 'hidden'; // hide body's scrollbar
 
       // Move `bib` by the amount the viewport is shifted to stay aligned in fullscreen.
-      this.element.bib.style.transform = `translateY(${visualViewport.offsetTop}px)`;
+      this.element.bib.style.transform = `translateY(${window?.visualViewport?.offsetTop}px)`;
     } else {
       document.body.style.overflow = '';
     }
@@ -240,7 +240,7 @@ export default class AuroFloatingUI {
         bibContent.style.width = '';
         bibContent.style.height = '';
         bibContent.style.maxWidth = '';
-        bibContent.style.maxHeight = `${window.visualViewport.height}px`;
+        bibContent.style.maxHeight = `${window?.visualViewport?.height}px`;
         this.configureTrial = 0;
       } else if (this.configureTrial < MAX_CONFIGURATION_COUNT) {
         this.configureTrial += 1;


### PR DESCRIPTION
# Alaska Airlines Pull Request

This is to fix a runtime error when floatingUI was running under VM or SSR enviroment where visualViewport does not get set. 

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
