### PR TITLE
refactor: enhance date parsing logic and validation in AuroDateUtilities

### DIFF
--- a/scripts/runtime/dateUtilities/dateFormatter.mjs
+++ b/scripts/runtime/dateUtilities/dateFormatter.mjs
@@ -1,22 +1,19 @@
 class DateFormatter {
-
   constructor() {
-
     /**
      * @description Parses a date string into its components.
      * @param {string} dateStr - Date string to parse.
      * @param {string} format - Date format to parse.
      * @returns {Object<key["month" | "day" | "year"]: number>|undefined}
      */
-    this.parseDate = (dateStr, format = 'mm/dd/yyyy') => {
-
+    this.parseDate = (dateStr, format = "mm/dd/yyyy") => {
       // Guard Clause: Date string is defined
       if (!dateStr) {
         return undefined;
       }
 
       // Assume the separator is a "/" a defined in our code base
-      const separator = '/';
+      const separator = "/";
 
       // Get the parts of the date and format
       const valueParts = dateStr.split(separator);
@@ -24,31 +21,35 @@ class DateFormatter {
 
       // Check if the value and format have the correct number of parts
       if (valueParts.length !== formatParts.length) {
-        throw new Error('AuroDatepickerUtilities | parseDate: Date string and format length do not match');
+        throw new Error(
+          "AuroDatepickerUtilities | parseDate: Date string and format length do not match",
+        );
       }
 
       // Holds the result to be returned
       const result = formatParts.reduce((acc, part, index) => {
         const value = valueParts[index];
 
-        if ((/m/iu).test(part)) {
+        if (/m/iu.test(part)) {
           acc.month = value;
-        } else if ((/d/iu).test(part)) {
+        } else if (/d/iu.test(part)) {
           acc.day = value;
-        } else if ((/y/iu).test(part)) {
+        } else if (/y/iu.test(part)) {
           acc.year = value;
         }
 
         return acc;
       }, {});
 
-      // If we found all the parts, return the result
-      if (result.month && result.year) {
+      // If we found at least one part, return the result
+      if (result.month || result.day || result.year) {
         return result;
       }
 
       // Throw an error to let the dev know we were unable to parse the date string
-      throw new Error('AuroDatepickerUtilities | parseDate: Unable to parse date string');
+      throw new Error(
+        "AuroDatepickerUtilities | parseDate: Unable to parse date string",
+      );
     };
 
     /**
@@ -57,11 +58,12 @@ class DateFormatter {
      * @param {String} locale - Optional locale to use for the date string. Defaults to user's locale.
      * @returns {String} Returns the date as a string.
      */
-    this.getDateAsString = (date, locale = undefined) => date.toLocaleDateString(locale, {
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-    });
+    this.getDateAsString = (date, locale = undefined) =>
+      date.toLocaleDateString(locale, {
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+      });
 
     /**
      * Converts a date string to a North American date format.
@@ -70,15 +72,16 @@ class DateFormatter {
      * @returns {Boolean}
      */
     this.toNorthAmericanFormat = (dateStr, format) => {
-
-      if (format === 'mm/dd/yyyy') {
+      if (format === "mm/dd/yyyy") {
         return dateStr;
       }
 
       const parsedDate = this.parseDate(dateStr, format);
 
       if (!parsedDate) {
-        throw new Error('AuroDatepickerUtilities | toNorthAmericanFormat: Unable to parse date string');
+        throw new Error(
+          "AuroDatepickerUtilities | toNorthAmericanFormat: Unable to parse date string",
+        );
       }
 
       const { month, day, year } = parsedDate;
@@ -96,9 +99,9 @@ class DateFormatter {
         dateParts.push(year);
       }
 
-      return dateParts.join('/');
+      return dateParts.join("/");
     };
   }
-};
+}
 
 export const dateFormatter = new DateFormatter();

--- a/scripts/runtime/dateUtilities/dateUtilities.mjs
+++ b/scripts/runtime/dateUtilities/dateUtilities.mjs
@@ -3,12 +3,11 @@ import { AuroDateUtilitiesBase } from "./baseDateUtilities.mjs";
 import { dateFormatter } from "./dateFormatter.mjs";
 
 export class AuroDateUtilities extends AuroDateUtilitiesBase {
-
   /**
    * Returns the current century.
    * @returns {String} The current century.
    */
-  getCentury () {
+  getCentury() {
     return String(new Date().getFullYear()).slice(0, 2);
   }
 
@@ -17,14 +16,12 @@ export class AuroDateUtilities extends AuroDateUtilitiesBase {
    * @param {String} year - The year to convert to four digits.
    * @returns {String} The four digit year.
    */
-  getFourDigitYear (year) {
-
+  getFourDigitYear(year) {
     const strYear = String(year).trim();
     return strYear.length <= 2 ? this.getCentury() + strYear : strYear;
   }
 
   constructor() {
-
     super();
 
     /**
@@ -33,7 +30,8 @@ export class AuroDateUtilities extends AuroDateUtilitiesBase {
      * @param {Object} date2 - Second date to compare.
      * @returns {Boolean} Returns true if the dates match.
      */
-    this.datesMatch = (date1, date2) => new Date(date1).getTime() === new Date(date2).getTime();
+    this.datesMatch = (date1, date2) =>
+      new Date(date1).getTime() === new Date(date2).getTime();
 
     /**
      * Returns true if value passed in is a valid date.
@@ -42,29 +40,34 @@ export class AuroDateUtilities extends AuroDateUtilitiesBase {
      * @returns {Boolean}
      */
     this.validDateStr = (date, format) => {
-
       // The length we expect the date string to be
       const dateStrLength = format.length;
 
       // Guard Clause: Date and format are defined
       if (typeof date === "undefined" || typeof format === "undefined") {
-        throw new Error('AuroDatepickerUtilities | validateDateStr: Date and format are required');
+        throw new Error(
+          "AuroDatepickerUtilities | validateDateStr: Date and format are required",
+        );
       }
 
       // Guard Clause: Date should be of type string
       if (typeof date !== "string") {
-        throw new Error('AuroDatepickerUtilities | validateDateStr: Date must be a string');
+        throw new Error(
+          "AuroDatepickerUtilities | validateDateStr: Date must be a string",
+        );
       }
 
       // Guard Clause: Format should be of type string
       if (typeof format !== "string") {
-        throw new Error('AuroDatepickerUtilities | validateDateStr: Format must be a string');
+        throw new Error(
+          "AuroDatepickerUtilities | validateDateStr: Format must be a string",
+        );
       }
 
       // Guard Clause: Length is what we expect it to be
       if (date.length !== dateStrLength) {
         return false;
-      };
+      }
 
       // Get a formatted date string and parse it
       const dateParts = dateFormatter.parseDate(date, format);
@@ -75,10 +78,13 @@ export class AuroDateUtilities extends AuroDateUtilitiesBase {
       }
 
       // Create the expected date string based on the date parts
-      const expectedDateStr = `${dateParts.month}/${dateParts.day || "01"}/${this.getFourDigitYear(dateParts.year)}`;
+      const month = dateParts.month || "01";
+      const day = dateParts.day || "01";
+      const year = this.getFourDigitYear(dateParts.year || "2000");
+      const expectedDateStr = `${month}/${day}/${year}`;
 
       // Generate a date object that we will extract a string date from to compare to the passed in date string
-      const dateObj = new Date(this.getFourDigitYear(dateParts.year), dateParts.month - 1, dateParts.day || 1);
+      const dateObj = new Date(year, month - 1, day);
 
       // Get the date string of the date object we created from the string date
       const actualDateStr = dateFormatter.getDateAsString(dateObj, "en-US");
@@ -99,10 +105,11 @@ export class AuroDateUtilities extends AuroDateUtilitiesBase {
      * @returns {boolean}
      */
     this.dateAndFormatMatch = (value, format) => {
-
       // Ensure we have both values we need to do the comparison
       if (!value || !format) {
-        throw new Error('AuroFormValidation | dateFormatMatch: value and format are required');
+        throw new Error(
+          "AuroFormValidation | dateFormatMatch: value and format are required",
+        );
       }
 
       // If the lengths are different, they cannot match
@@ -115,7 +122,6 @@ export class AuroDateUtilities extends AuroDateUtilitiesBase {
 
       // Validator for day
       const dayValueIsValid = (day) => {
-
         // Guard clause: if there is no day in the dateParts, we can ignore this check.
         if (!dateParts.day) {
           return true;
@@ -131,7 +137,9 @@ export class AuroDateUtilities extends AuroDateUtilitiesBase {
 
         // Guard clause: ensure day is a valid integer
         if (Number.isNaN(numDay)) {
-          throw new Error('AuroDatepickerUtilities | dayValueIsValid: Unable to parse day value integer');
+          throw new Error(
+            "AuroDatepickerUtilities | dayValueIsValid: Unable to parse day value integer",
+          );
         }
 
         // Guard clause: ensure day is within the valid range
@@ -145,6 +153,10 @@ export class AuroDateUtilities extends AuroDateUtilitiesBase {
 
       // Validator for month
       const monthValueIsValid = (month) => {
+        // Guard clause: if there is no month in the dateParts, we can ignore this check.
+        if (!dateParts.month) {
+          return true;
+        }
 
         // Guard clause: ensure month exists.
         if (!month) {
@@ -156,7 +168,9 @@ export class AuroDateUtilities extends AuroDateUtilitiesBase {
 
         // Guard clause: ensure month is a valid integer
         if (Number.isNaN(numMonth)) {
-          throw new Error('AuroDatepickerUtilities | monthValueIsValid: Unable to parse month value integer');
+          throw new Error(
+            "AuroDatepickerUtilities | monthValueIsValid: Unable to parse month value integer",
+          );
         }
 
         // Guard clause: ensure month is within the valid range
@@ -170,6 +184,10 @@ export class AuroDateUtilities extends AuroDateUtilitiesBase {
 
       // Validator for year
       const yearIsValid = (_year) => {
+        // Guard clause: if there is no year in the dateParts, we can ignore this check.
+        if (!dateParts.year) {
+          return true;
+        }
 
         // Guard clause: ensure year exists.
         if (!_year) {
@@ -184,7 +202,9 @@ export class AuroDateUtilities extends AuroDateUtilitiesBase {
 
         // Guard clause: ensure year is a valid integer
         if (Number.isNaN(numYear)) {
-          throw new Error('AuroDatepickerUtilities | yearValueIsValid: Unable to parse year value integer');
+          throw new Error(
+            "AuroDatepickerUtilities | yearValueIsValid: Unable to parse year value integer",
+          );
         }
 
         // Guard clause: ensure year is within the valid range
@@ -200,7 +220,7 @@ export class AuroDateUtilities extends AuroDateUtilitiesBase {
       const checks = [
         monthValueIsValid(dateParts.month),
         dayValueIsValid(dateParts.day),
-        yearIsValid(dateParts.year)
+        yearIsValid(dateParts.year),
       ];
 
       // If any of the checks failed, the date format does not match and the result is invalid


### PR DESCRIPTION
### Summary
- Fix `parseDate()` in `dateFormatter.mjs` to accept results with any extracted component, not just month+year
- Fix `dateAndFormatMatch()` validators in `dateUtilities.mjs` to skip validation for components not present in the format
- Fix `validDateStr()` in `dateUtilities.mjs` to default missing components when constructing comparison dates

### Test plan
- Verify single-component formats (`yy`, `yyyy`, `mm`, `dd`) no longer throw in `parseDate()`
- Verify `dateAndFormatMatch()` returns `true` for valid single-component values (e.g. `"12"` with format `"mm"`)
- Verify `validDateStr()` returns `true` for valid single-component date strings
- Verify all existing multi-component format tests still pass (no regressions)

---

## Files to Change

### 1. `scripts/runtime/dateUtilities/dateFormatter.mjs`

#### `parseDate()` — line 46

**Problem:** The guard clause requires both `month` AND `year` to be present. Single-component formats only produce one field, so `parseDate` always throws for them.

**Before:**
```js
// If we found all the parts, return the result
if (result.month && result.year) {
  return result;
}
```

**After:**
```js
// If we found at least one part, return the result
if (result.month || result.day || result.year) {
  return result;
}
```

---

### 2. `scripts/runtime/dateUtilities/dateUtilities.mjs`

#### `dateAndFormatMatch()` — `monthValueIsValid` validator (~line 150)

**Problem:** Returns `false` when `month` is `undefined`, but for formats that don't include month (e.g. `dd`, `yy`), `undefined` is the expected value. The `dayValueIsValid` validator already handles this correctly with an early `return true` guard — month and year validators need the same pattern.

**Before:**
```js
// Validator for month
const monthValueIsValid = (month) => {

  // Guard clause: ensure month exists.
  if (!month) {
    return false;
  }
```

**After:**
```js
// Validator for month
const monthValueIsValid = (month) => {

  // Guard clause: if there is no month in the dateParts, we can ignore this check.
  if (!dateParts.month) {
    return true;
  }

  // Guard clause: ensure month exists.
  if (!month) {
    return false;
  }
```

#### `dateAndFormatMatch()` — `yearIsValid` validator (~line 180)

**Problem:** Same issue as `monthValueIsValid` — returns `false` for `undefined` year, but year-less formats like `mm` or `dd` don't have a year component.

**Before:**
```js
// Validator for year
const yearIsValid = (_year) => {

  // Guard clause: ensure year exists.
  if (!_year) {
    return false;
  }
```

**After:**
```js
// Validator for year
const yearIsValid = (_year) => {

  // Guard clause: if there is no year in the dateParts, we can ignore this check.
  if (!dateParts.year) {
    return true;
  }

  // Guard clause: ensure year exists.
  if (!_year) {
    return false;
  }
```

#### `validDateStr()` — expected date string construction (~line 78)

**Problem:** Constructs a comparison date string assuming `month` and `year` always exist. For single-component formats, missing components are `undefined`, producing strings like `"undefined/01/20undefined"` which fail the comparison.

**Before:**
```js
// Create the expected date string based on the date parts
const expectedDateStr = `${dateParts.month}/${dateParts.day || "01"}/${this.getFourDigitYear(dateParts.year)}`;

// Generate a date object that we will extract a string date from to compare to the passed in date string
const dateObj = new Date(this.getFourDigitYear(dateParts.year), dateParts.month - 1, dateParts.day || 1);
```

**After:**
```js
// Create the expected date string based on the date parts
const month = dateParts.month || "01";
const day = dateParts.day || "01";
const year = this.getFourDigitYear(dateParts.year || "2000");
const expectedDateStr = `${month}/${day}/${year}`;

// Generate a date object that we will extract a string date from to compare to the passed in date string
const dateObj = new Date(year, month - 1, day);
```

## Summary by Sourcery

Relax date parsing and validation utilities to better support partial date formats while improving error handling and defaults.

Bug Fixes:
- Allow parseDate to successfully parse and return results for formats containing only a subset of date components (month, day, or year).
- Ensure dateAndFormatMatch validators skip month/year checks when those components are not present in the parsed date format.
- Make validDateStr construct comparison dates with sensible default month/day/year values to avoid failures for partial date inputs.

Enhancements:
- Improve robustness and readability of date utility methods with clearer guard clauses, consistent string quoting, and multi-line formatting for complex expressions.