### PR TITLE
Add touch handler to floatingUI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aurodesignsystem/auro-library",
-  "version": "5.7.0",
+  "version": "5.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aurodesignsystem/auro-library",
-      "version": "5.7.0",
+      "version": "5.12.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@floating-ui/dom": "^1.7.4",

--- a/scripts/runtime/floatingUI.mjs
+++ b/scripts/runtime/floatingUI.mjs
@@ -70,6 +70,7 @@ export default class AuroFloatingUI {
     this.focusHandler = null;
     this.clickHandler = null;
     this.keyDownHandler = null;
+    this.touchHandler = null;
 
     /**
      * @private
@@ -487,6 +488,28 @@ export default class AuroFloatingUI {
     setTimeout(() => {
       window.addEventListener("click", this.clickHandler);
     }, 0);
+
+    // iOS Safari does not fire `click` on non-interactive elements, so
+    // tapping an inert backdrop never reaches the click handler above.
+    // Mirror the same outside-tap logic with a passive touchstart listener.
+    this.touchHandler = (evt) => {
+      const element = this.element;
+      if (!element?.bib) {
+        return;
+      }
+
+      // fullscreen (modal) dialog handles its own dismissal
+      if (element.bib.hasAttribute("isfullscreen")) {
+        return;
+      }
+
+      const path = evt.composedPath();
+      if (!path.includes(element.trigger) && !path.includes(element.bib)) {
+        this.hideBib("click");
+      }
+    };
+
+    window.addEventListener("touchstart", this.touchHandler, { passive: true });
   }
 
   cleanupHideHandlers() {
@@ -500,6 +523,11 @@ export default class AuroFloatingUI {
     if (this.clickHandler) {
       window.removeEventListener("click", this.clickHandler);
       this.clickHandler = null;
+    }
+
+    if (this.touchHandler) {
+      window.removeEventListener("touchstart", this.touchHandler);
+      this.touchHandler = null;
     }
 
     if (this.keyDownHandler) {


### PR DESCRIPTION
# Alaska Airlines Pull Request

Issue:
- https://dev.azure.com/itsals/E_Retain_Content/_workitems/edit/1536436

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Ensure floating UI popovers are dismissed on outside interaction consistently across browsers, including iOS Safari.

Bug Fixes:
- Fix floating UI popovers not dismissing on outside taps in iOS Safari due to missing click events on non-interactive elements.

Enhancements:
- Add a passive touchstart-based outside-tap handler to mirror existing click-based dismissal and clean it up with other hide handlers.