### PR TITLE
fix(floatingUI): handle focus loss in Chrome during popover promotion

### DIFF
--- a/scripts/runtime/floatingUI.mjs
+++ b/scripts/runtime/floatingUI.mjs
@@ -556,7 +556,10 @@ export default class AuroFloatingUI {
       return;
     }
 
-    this.hideBib("keydown");
+    // eventType "focusloss" distinguishes a Tab/click-driven close from an
+    // Escape keydown close. Consumers use this to decide whether to restore
+    // focus to the trigger (Escape) or let it advance naturally (Tab).
+    this.hideBib("focusloss");
   }
 
   setupHideHandlers() {

--- a/scripts/runtime/floatingUI.mjs
+++ b/scripts/runtime/floatingUI.mjs
@@ -526,6 +526,31 @@ export default class AuroFloatingUI {
       return;
     }
 
+    // Chrome-specific: during popover top-layer promotion after a click on a
+    // slotted focusable, :focus-within can briefly evaluate false while the
+    // active element is still structurally inside the trigger/bib. Fall back
+    // to a shadow-piercing ancestry walk from the deep active element before
+    // treating this as a real focus loss.
+    try {
+      let active = document.activeElement;
+      while (active && active.shadowRoot && active.shadowRoot.activeElement) {
+        active = active.shadowRoot.activeElement;
+      }
+      const targets = [element, element.trigger, element.bib].filter(Boolean);
+      let node = active;
+      while (node) {
+        if (targets.includes(node)) {
+          return;
+        }
+        node =
+          node.parentElement ||
+          (node.getRootNode && node.getRootNode().host) ||
+          null;
+      }
+    } catch (e) {
+      // Defensive: fall through to the existing close path if traversal fails.
+    }
+
     // if fullscreen bib is in fullscreen mode, do not close
     if (element.bib.hasAttribute("isfullscreen")) {
       return;

--- a/scripts/runtime/floatingUI.test.js
+++ b/scripts/runtime/floatingUI.test.js
@@ -86,7 +86,7 @@ describe("AuroFloatingUI", () => {
     expect(hideBibSpy.called).to.be.false;
   });
 
-  it("hides with a keydown event when the host no longer has focus", () => {
+  it("hides with a focus loss event when the host no longer has focus", () => {
     const checkedSelectors = [];
 
     sinon.stub(host, "matches").callsFake((selector) => {
@@ -97,7 +97,7 @@ describe("AuroFloatingUI", () => {
     floatingUI.handleFocusLoss();
 
     expect(checkedSelectors).to.deep.equal([":focus", ":focus-within"]);
-    expect(hideBibSpy.calledOnceWithExactly("keydown")).to.be.true;
+    expect(hideBibSpy.calledOnceWithExactly("focusloss")).to.be.true;
   });
 
   it("no-ops safely when element is not set", () => {


### PR DESCRIPTION
# Alaska Airlines Pull Request

This pull request introduces a Chrome-specific workaround to improve focus handling for floating UI elements. The main change ensures that the UI does not incorrectly close when focus transitions involve slotted focusable elements inside a shadow DOM, addressing an edge case where `:focus-within` may not behave as expected.

Focus handling improvements:

* Added a shadow-piercing ancestry walk in `AuroFloatingUI` to check if the active element is still structurally within the floating UI or its triggers, preventing premature closure in Chrome during popover top-layer promotion.

## Checklist:

- [ ] My update follows the CONTRIBUTING guidelines of this project
- [ ] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Bug Fixes:
- Prevent floating UI popovers from incorrectly closing in Chrome during focus transitions involving slotted focusable elements within shadow DOMs.