### PR TITLE
fix: track visualViewport continuously during scroll lock

### DIFF
--- a/scripts/runtime/floatingUI.mjs
+++ b/scripts/runtime/floatingUI.mjs
@@ -339,15 +339,57 @@ export default class AuroFloatingUI {
         document.body.style.top = `-${this._savedScrollY}px`;
         document.body.style.width = "100%";
 
-        // Move `bib` by the amount the viewport is shifted to stay aligned in fullscreen.
-        if (element?.bib && window?.visualViewport?.offsetTop) {
-          element.bib.style.transform = `translateY(${window?.visualViewport?.offsetTop}px)`;
+        // Keep the bib aligned with the visual viewport as the VKB opens.
+        // A one-shot offsetTop check at lock time is stale by the time the user
+        // taps an input mid-drawer — iOS then pans visualViewport upward and the
+        // bib drifts off-screen. Listen continuously so the transform tracks the pan.
+        // RAF-throttled to avoid a style recalc on every scroll tick during the
+        // keyboard animation; the pending frame is canceled on unlock so it cannot
+        // reapply a translate after bibTransform has been restored.
+        if (window.visualViewport) {
+          this._viewportRafId = undefined;
+          this._viewportHandler = () => {
+            if (this._viewportRafId !== undefined) {
+              return;
+            }
+            this._viewportRafId = requestAnimationFrame(() => {
+              this._viewportRafId = undefined;
+              if (element?.bib) {
+                element.bib.style.transform = `translateY(${window.visualViewport.offsetTop}px)`;
+              }
+            });
+          };
+          window.visualViewport.addEventListener(
+            "resize",
+            this._viewportHandler,
+          );
+          window.visualViewport.addEventListener(
+            "scroll",
+            this._viewportHandler,
+          );
+          this._viewportHandler();
         }
 
         this.lockTouchScroll(true);
       }
     } else {
       if (this._scrollLocked) {
+        if (this._viewportHandler && window.visualViewport) {
+          window.visualViewport.removeEventListener(
+            "resize",
+            this._viewportHandler,
+          );
+          window.visualViewport.removeEventListener(
+            "scroll",
+            this._viewportHandler,
+          );
+          this._viewportHandler = undefined;
+        }
+        if (this._viewportRafId !== undefined) {
+          cancelAnimationFrame(this._viewportRafId);
+          this._viewportRafId = undefined;
+        }
+
         document.documentElement.style.scrollbarGutter =
           this._savedScrollStyles?.rootScrollbarGutter ?? "";
         document.documentElement.style.overflow =
@@ -439,7 +481,7 @@ export default class AuroFloatingUI {
         bibContent.style.width = "";
         bibContent.style.height = "";
         bibContent.style.maxWidth = "";
-        bibContent.style.maxHeight = `${window?.visualViewport?.height}px`;
+        bibContent.style.maxHeight = "";
         this.configureTrial = 0;
       } else if (this.configureTrial < MAX_CONFIGURATION_COUNT) {
         this.configureTrial += 1;


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Track and clean up continuous visualViewport listeners during scroll lock to keep the bib aligned with the viewport on virtual keyboard interactions.

Bug Fixes:
- Prevent the bib from drifting off-screen on iOS when visualViewport pans during drawer interactions while scroll is locked.

Enhancements:
- Throttle visualViewport scroll and resize handling with requestAnimationFrame and ensure listeners and pending frames are removed on unlock.