### PR TITLE
Suppress Escape keydown for modal AuroFloatingUI dialogs

### DIFF
--- a/docs/post-mortem/1613688.md
+++ b/docs/post-mortem/1613688.md
@@ -1,0 +1,119 @@
+# AB#1613688 — Modal Dialog: Double-Esc Leaves Invisible Click-Blocking Overlay
+
+**Scope:** 1 file changed in `auro-library` — `scripts/runtime/floatingUI.mjs` (`showBib()` modal branch). Companion fix in `auro-dialog`: `src/componentBase.js` (`close` event safety-net listener).
+
+## Executive Summary
+
+A modal `auro-dialog` could be force-closed by pressing Esc twice in rapid succession, leaving an invisible full-viewport overlay blocking all page interaction, an orphaned focus trap, and component state permanently out of sync with the browser. The root cause was that `floatingUI` only intercepted the native `cancel` event — too late in the event chain. The browser's CloseWatcher anti-trap mechanism skips `cancel` entirely on a second Esc with no intervening user activation, firing `close` directly and bypassing the guard. The fix moves the interception earlier: a `keydown` listener added for modal dialogs swallows Escape before the browser ever processes it, so the `cancel` / `close` path is never reached.
+
+---
+
+### Section 1 — The Problem
+
+`auro-dialog` with `modal=true` is designed to be dismissible only via an explicit user action (the close button). Pressing Esc should have no effect.
+
+The first Esc was correctly absorbed: `componentBase.js` listened for the native `cancel` event on the `<dialog>` element and called `e.preventDefault()`. For modal dialogs it did not call `hide()`, so the dialog stayed open.
+
+The second Esc — pressed without any intervening click, focus change, or other user activation — triggered the browser's **CloseWatcher anti-trap** safety mechanism. The spec mandates that if a `cancel` event is suppressed without user activation, the next Esc must be able to escape regardless. The browser fires a **`close` event** instead of `cancel`, which force-closes the native `<dialog>` element before any JavaScript can prevent it.
+
+Because the component had no `close` listener, its teardown never ran:
+
+- The native `::backdrop` disappeared (the browser closed the dialog)
+- `isPopoverVisible` remained `true` — the `open` attribute stayed on the host element
+- `#dialog-overlay` (a legacy compatibility div) kept `pointer-events: unset`, becoming an invisible full-viewport layer that swallowed all mouse and touch events
+- The `FocusTrap` instance stayed connected, trapping keyboard focus inside a dialog that was no longer in the top layer
+- Focus was never restored to the trigger element
+
+The result: a completely non-interactable page with no visible indication of failure, reproducible every time with two Esc presses on any modal dialog.
+
+---
+
+### Section 2 — Root Cause (Code-Level)
+
+In `scripts/runtime/floatingUI.mjs`, `showBib()` branched on `element.modal`:
+
+```javascript
+if (!element.modal) {
+  this.setupHideHandlers(); // registers keydown → hideBib("keydown") for non-modal
+}
+// modal: no handlers registered at all
+```
+
+For modal dialogs, `floatingUI` registered nothing. The `cancel`-event guard in `componentBase.js` was the entire defense. That guard worked for the first Esc, but the CloseWatcher anti-trap bypasses `cancel` on the second Esc — no amount of `preventDefault()` on `cancel` can stop a force-`close` once the anti-trap fires.
+
+The `close` event on `<dialog>` is not cancelable and fires after the browser has already removed the dialog from the top layer.
+
+---
+
+### Section 3 — The Fix
+
+**Primary fix — `floatingUI.mjs` `showBib()`:**
+
+For `element.modal === true`, instead of skipping handler setup entirely, register a `keydown` listener on `document` that intercepts Escape *before* the browser processes it:
+
+```javascript
+} else {
+  if (this.keyDownHandler) {
+    document.removeEventListener("keydown", this.keyDownHandler);
+  }
+  this.keyDownHandler = (evt) => {
+    if (evt.key === "Escape" && element.isPopoverVisible) {
+      evt.preventDefault();
+      evt.stopImmediatePropagation();
+    }
+  };
+  document.addEventListener("keydown", this.keyDownHandler);
+}
+```
+
+`preventDefault()` on `keydown` prevents the browser from treating the keystroke as a dialog-close intent — neither `cancel` nor `close` ever fires. `stopImmediatePropagation()` prevents other listeners from acting on the key. Since this runs at the `keydown` level, the CloseWatcher never sees the Escape and its anti-trap counter never increments.
+
+Cleanup is handled by the existing `cleanupHideHandlers()`, which already removes `this.keyDownHandler` if set — no additional teardown code needed.
+
+**Companion fix — `componentBase.js` `firstUpdated()`:**
+
+A `close` event listener was also added to the native `<dialog>` element as defense-in-depth for any path that force-closes the dialog outside the normal `hide()` flow:
+
+```javascript
+this.dialog.addEventListener('close', () => {
+  if (this.floater.showing) {
+    this.hide();
+  }
+});
+```
+
+The `floater.showing` guard (matching the pattern already used in `updated()`) prevents double-teardown on the normal `hide()` path, where `floater.hideBib()` sets `showing = false` before `dialog.close()` fires the event.
+
+---
+
+### Section 4 — Test Coverage
+
+Four regression tests added to `scripts/runtime/floatingUI.test.js` in a dedicated `describe` block:
+
+1. `registers a keydown handler and skips setupHideHandlers when modal=true` — verifies the modal branch runs instead of `setupHideHandlers`, and `keyDownHandler` is set
+2. `does not call hideBib when Escape is pressed while modal dialog is open` — verifies `hideBib` is never called on Escape
+3. `calls preventDefault on Escape keydown while modal dialog is open` — the direct regression test for AB#1613688; verifies the `keydown` guard actually calls `preventDefault`
+4. `removes the modal Escape keydown handler via cleanupHideHandlers` — verifies the handler is properly torn down on close so it cannot fire after the dialog is gone
+
+---
+
+### Section 5 — Risk Assessment
+
+| Risk | Mitigation |
+|---|---|
+| Double-teardown when normal `hide()` calls `dialog.close()` | `floater.showing` guard in the `close` listener — `hideBib()` sets `showing = false` before `dialog.close()` fires, so the listener is a no-op on the normal path |
+| Modal keydown handler leaking after dialog closes | `cleanupHideHandlers()` already removes `keyDownHandler` — no new teardown path needed; covered by test 4 |
+| Non-modal dialogs accidentally suppressing Escape | The `else` branch in `showBib()` only runs when `element.modal === true`; non-modal dialogs still go through `setupHideHandlers()` unchanged |
+| `stopImmediatePropagation` blocking legitimate listeners | Only fires on Escape while the modal is open (`element.isPopoverVisible`); no other keydown behavior is affected |
+
+---
+
+### Key Lessons
+
+1. **Intercept at `keydown`, not at `cancel`.** The `cancel` event on `<dialog>` is a browser-managed shortcut — the browser can and will bypass it via CloseWatcher anti-trap. `keydown` fires before any browser dialog processing and is the correct interception point for modal keyboard suppression.
+
+2. **The CloseWatcher anti-trap is intentional and unfightable after the fact.** Once the browser fires `close` (as opposed to `cancel`), the dialog is already closed and cannot be reopened synchronously. Handling must happen upstream, at `keydown`, not downstream after the damage is done.
+
+3. **Silent accessibility failures are the most dangerous regressions.** The page rendered visually intact. No console errors fired. The failure was purely behavioral — an invisible overlay and a stranded focus trap — observable only to users who tried to interact with the page after double-Esc. Explicit regression tests are required; visual inspection cannot catch this class of bug.
+
+4. **Defense-in-depth is cheap.** The `close` event listener in `componentBase.js` costs one event listener and a one-line guard. It covers any future force-close path (browser behavior changes, programmatic `dialog.close()` calls from consumer code) without interfering with the normal close path.

--- a/scripts/runtime/floatingUI.mjs
+++ b/scripts/runtime/floatingUI.mjs
@@ -778,6 +778,24 @@ export default class AuroFloatingUI {
       if (!this.showing) {
         if (!element.modal) {
           this.setupHideHandlers();
+        } else {
+          if (this.keyDownHandler) {
+            document.removeEventListener("keydown", this.keyDownHandler);
+          }
+          this.keyDownHandler = (evt) => {
+            if (evt.key === "Escape" && element.isPopoverVisible) {
+              // Intercept at keydown so CloseWatcher never sees the keystroke.
+              // Canceling `cancel` alone is insufficient — a second Esc with no
+              // intervening user activation triggers the anti-trap and fires `close`
+              // directly, bypassing any `cancel` preventDefault (AB#1613688).
+              // stopImmediatePropagation is intentional: it prevents other document
+              // keydown handlers (e.g. consumer code, auro-dialog) from also acting
+              // on Escape while the modal owns the key.
+              evt.preventDefault();
+              evt.stopImmediatePropagation();
+            }
+          };
+          document.addEventListener("keydown", this.keyDownHandler);
         }
         this.showing = true;
         element.isPopoverVisible = true;

--- a/scripts/runtime/floatingUI.test.js
+++ b/scripts/runtime/floatingUI.test.js
@@ -295,6 +295,85 @@ describe("AuroFloatingUI", () => {
   });
 });
 
+describe("AuroFloatingUI modal Escape suppression (AB#1613688)", () => {
+  let host;
+  let bib;
+  let floatingUI;
+  let hideBibSpy;
+
+  beforeEach(() => {
+    host = document.createElement("div");
+    bib = document.createElement("div");
+    host.bib = bib;
+    host.modal = true;
+    host.isPopoverVisible = false;
+    host.triggerChevron = document.createElement("span");
+    document.body.append(host, bib);
+
+    AuroFloatingUI.openingQueue = [];
+    document.expandedAuroFloater = null;
+
+    floatingUI = new AuroFloatingUI(host, "dialog");
+    hideBibSpy = sinon.spy(floatingUI, "hideBib");
+  });
+
+  afterEach(() => {
+    floatingUI.cleanupHideHandlers();
+    sinon.restore();
+    AuroFloatingUI.isMousePressed = false;
+    AuroFloatingUI.openingQueue = [];
+    document.expandedAuroFloater = null;
+    host?.remove();
+    bib?.remove();
+  });
+
+  it("registers a keydown handler and skips setupHideHandlers when modal=true", () => {
+    const setupHideHandlersSpy = sinon.spy(floatingUI, "setupHideHandlers");
+
+    floatingUI.showBib();
+
+    expect(setupHideHandlersSpy.called).to.be.false;
+    expect(floatingUI.keyDownHandler).to.be.a("function");
+    expect(floatingUI.showing).to.be.true;
+  });
+
+  it("does not call hideBib when Escape is pressed while modal dialog is open", () => {
+    floatingUI.showBib();
+
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "Escape",
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+
+    expect(hideBibSpy.called).to.be.false;
+  });
+
+  it("calls preventDefault on Escape keydown while modal dialog is open", () => {
+    floatingUI.showBib();
+
+    const escEvent = new KeyboardEvent("keydown", {
+      key: "Escape",
+      bubbles: true,
+      cancelable: true,
+    });
+    const preventDefaultSpy = sinon.spy(escEvent, "preventDefault");
+    document.dispatchEvent(escEvent);
+
+    expect(preventDefaultSpy.calledOnce).to.be.true;
+  });
+
+  it("removes the modal Escape keydown handler via cleanupHideHandlers", () => {
+    floatingUI.showBib();
+    expect(floatingUI.keyDownHandler).to.be.a("function");
+
+    floatingUI.cleanupHideHandlers();
+    expect(floatingUI.keyDownHandler).to.be.null;
+  });
+});
+
 describe("AuroFloatingUI.openingQueue and topOpeningFloatingUI", () => {
   let floatingUI1;
   let floatingUI2;


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

<!-- claude-code-review:pm-exec-summary:start -->
## Executive Summary

A modal `auro-dialog` could be force-closed by pressing Esc twice in rapid succession, leaving an invisible full-viewport overlay blocking all page interaction, an orphaned focus trap, and component state permanently out of sync with the browser. The root cause was that `floatingUI` only intercepted the native `cancel` event — too late in the event chain. The browser's CloseWatcher anti-trap mechanism skips `cancel` entirely on a second Esc with no intervening user activation, firing `close` directly and bypassing the guard. The fix moves the interception earlier: a `keydown` listener added for modal dialogs swallows Escape before the browser ever processes it, so the `cancel` / `close` path is never reached.

<sub><i>Synced from <code>docs/post-mortem/1613688.md</code> by the code-review skill.</i></sub>
<!-- claude-code-review:pm-exec-summary:end -->

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Prevent modal floating UI dialogs from being force-closed by browser CloseWatcher by intercepting Escape at keydown for modal popovers.

Bug Fixes:
- Ensure modal dialogs no longer close or desynchronize state when Escape is pressed twice in rapid succession by suppressing Escape at the document keydown level for modal popovers.

Documentation:
- Add a detailed post-mortem document describing the double-Escape modal dialog failure, root cause, fix, and lessons learned.

Tests:
- Add regression tests verifying modal dialogs register a dedicated Escape keydown handler, do not call hide on Escape, preventDefault on Escape, and properly clean up the handler on teardown.
